### PR TITLE
Error handling

### DIFF
--- a/src/main/scala/fluent/TransformError.scala
+++ b/src/main/scala/fluent/TransformError.scala
@@ -1,0 +1,16 @@
+package fluent
+
+trait TransformError {
+  def message: String
+}
+
+object TransformError {
+  def apply(error: String): TransformError = TransformErrorMessage(error)
+  def apply(error: Throwable): TransformError = TransformErrorThrowable(error)
+
+  case class TransformErrorMessage(message: String) extends TransformError
+
+  case class TransformErrorThrowable(throwable: Throwable) extends TransformError {
+    override def message: String = throwable.getMessage
+  }
+}

--- a/src/main/scala/fluent/internal/Transformer.scala
+++ b/src/main/scala/fluent/internal/Transformer.scala
@@ -1,25 +1,30 @@
 package fluent.internal
 
-import cats.{ Applicative, Functor, Monoid }
-import shapeless.labelled.{ FieldType, field }
+import cats.{Applicative, Monoid, Traverse}
+import fluent.TransformError
+import shapeless.labelled.{FieldType, field}
 import shapeless.ops.record.Selector
-import shapeless.{ :+:, ::, CNil, Coproduct, Generic, HList, HNil, Inl, Inr, LabelledGeneric, Lazy }
+import shapeless.{:+:, ::, CNil, Coproduct, Generic, HList, HNil, Inl, Inr, LabelledGeneric, Lazy}
 
 import scala.util.Try
 
-trait Transformer[A, B] { def apply(a: A): B }
+trait Transformer[A, B] { def apply(a: A): Either[TransformError, B] }
 
 trait ImplicitTransformersPriority1 {
   implicit def hlistGlobalTransformer[A, K, V, T <: HList](implicit
     transformHead: Transformer[A, V],
     transformTail: Transformer[A, T]
   ): Transformer[A, FieldType[K, V] :: T] = new Transformer[A, FieldType[K, V] :: T] {
-    override def apply(a: A): ::[FieldType[K, V], T] = field[K](transformHead(a)) :: transformTail(a)
+    override def apply(a: A): Either[TransformError, FieldType[K, V] :: T] =
+      for {
+        h <- transformHead(a)
+        t <- transformTail(a)
+      } yield field[K](h) :: t
   }
 
   implicit def emptyMonoidTransformer[F[_], A, B](implicit monoid: Monoid[F[B]]): Transformer[A, F[B]] =
     new Transformer[A, F[B]] {
-      override def apply(a: A): F[B] = monoid.empty
+      override def apply(a: A): Either[TransformError, F[B]] = Right(monoid.empty)
     }
 }
 
@@ -31,10 +36,12 @@ trait ImplicitTransformersPriority2 extends ImplicitTransformersPriority1 {
     transformHead: Transformer[F, V],
     transformTail: Transformer[A, T]
   ): Transformer[A, FieldType[K, V] :: T] = new Transformer[A, FieldType[K, V] :: T] {
-    override def apply(a: A) = {
+    override def apply(a: A): Either[TransformError, FieldType[K, V] :: T] = {
       val r = deepHLister(generic.to(a))
-      val h = transformHead(selector(r))
-      field[K](h) :: transformTail(a)
+      for {
+        h <- transformHead(selector(r))
+        t <- transformTail(a)
+      } yield field[K](h) :: t
     }
   }
 }
@@ -46,72 +53,82 @@ trait ImplicitTransformersPriority3 extends ImplicitTransformersPriority2 {
     transformHead: Transformer[F, V],
     transformTail: Transformer[A, T]
   ): Transformer[A, FieldType[K, V] :: T] = new Transformer[A, FieldType[K, V] :: T] {
-    override def apply(a: A): ::[FieldType[K, V], T] = {
-      val h = transformHead(selector(generic.to(a)))
-      field[K](h) :: transformTail(a)
-    }
+    override def apply(a: A): Either[TransformError, FieldType[K, V] :: T] =
+      for {
+        h <- transformHead(selector(generic.to(a)))
+        t <- transformTail(a)
+      } yield field[K](h) :: t
   }
 
   implicit def fromSealedTransformer[A, Repr <: Coproduct, B](implicit
     generic: Generic.Aux[A, Repr],
     transform: Transformer[Repr, B]
   ): Transformer[A, B] = new Transformer[A, B] {
-    override def apply(a: A): B = transform(generic.to(a))
+    override def apply(a: A): Either[TransformError, B] = transform(generic.to(a))
   }
 
   implicit def fromCoprodTransformer[H, T <: Coproduct, B](implicit
     transformHead: Transformer[H, B],
     transformTail: Transformer[T, B]
   ): Transformer[H :+: T, B] = new Transformer[H :+: T, B] {
-    override def apply(a: H :+: T): B = a match {
+    override def apply(a: H :+: T): Either[TransformError, B] = a match {
       case Inl(h) => transformHead(h)
       case Inr(t) => transformTail(t)
     }
   }
 
   implicit def fromCnilTransformer[A]: Transformer[CNil, A] = new Transformer[CNil, A] {
-    override def apply(cnil: CNil): A =
+    override def apply(cnil: CNil): Either[TransformError, A] =
       // there is no CNil instance, so this is never executed
-      throw new UnsupportedOperationException("Can't transform CNil")
+      Left(TransformError("Can't transform CNil"))
   }
 
   implicit def toSealedTransformer[A, Repr <: Coproduct, B](implicit
     generic: Generic.Aux[B, Repr],
     transform: Transformer[A, Repr]
   ): Transformer[A, B] = new Transformer[A, B] {
-    override def apply(a: A): B = generic.from(transform(a))
+    override def apply(a: A): Either[TransformError, B] = transform(a) map generic.from
   }
 
   implicit def toCoprodTransformer[A, H, T <: Coproduct](implicit
     transformHead: Transformer[A, H],
     transformTail: Transformer[A, T]
   ): Transformer[A, H :+: T] = new Transformer[A, H :+: T] {
-    override def apply(a: A): H :+: T = Try(Inl(transformHead(a))) getOrElse Inr(transformTail(a))
+    override def apply(a: A): Either[TransformError, H :+: T] =
+      transformHead(a).map(Inl.apply) match {
+        case h@Right(_) => h
+        case _ => transformTail(a).map(Inr.apply)
+      }
   }
 
   implicit def toCnilTransformer[A]: Transformer[A, CNil] = new Transformer[A, CNil] {
-    override def apply(a: A): CNil =
+    override def apply(a: A): Either[TransformError, CNil] =
       // There is no instance of CNil, so this won't be used
-      throw new UnsupportedOperationException("Can't transform into CNil")
+      Left(TransformError("Can't transform into CNil"))
   }
 }
 
 trait ImplicitTransformersPriority4 extends ImplicitTransformersPriority3 {
   implicit def customTransformer[A, B](implicit f: A => B): Transformer[A, B] = new Transformer[A, B] {
-    override def apply(a: A): B = f(a)
+    override def apply(a: A): Either[TransformError, B] =
+      Try(f(a)).toEither.left.map(TransformError.apply)
   }
   implicit def hlistCustomTransformer[A, K, V, T <: HList](implicit
     f: A => V,
     transformTail: Transformer[A, T]
   ): Transformer[A, FieldType[K, V] :: T] = new Transformer[A, FieldType[K, V] :: T] {
-    override def apply(a: A): FieldType[K, V] :: T = field[K](f(a)) :: transformTail(a)
+    override def apply(a: A): Either[TransformError, FieldType[K, V] :: T] =
+    for {
+      h <- Try(f(a)).toEither.left.map(TransformError.apply)
+      t <- transformTail(a)
+    } yield field[K](h) :: t
   }
 
   implicit def genericTransformer[A, B, BRepr <: HList](implicit
     generic: LabelledGeneric.Aux[B, BRepr],
     transform: Lazy[Transformer[A, BRepr]]
   ): Transformer[A, B] = new Transformer[A, B] {
-    override def apply(a: A): B = generic.from(transform.value(a))
+    override def apply(a: A): Either[TransformError, B] = transform.value(a) map generic.from
   }
 
   implicit def headTransformer[A, ARepr <: HList, F, K, V](implicit
@@ -119,38 +136,41 @@ trait ImplicitTransformersPriority4 extends ImplicitTransformersPriority3 {
     selector: Selector.Aux[ARepr, K, F],
     transform: Transformer[F, V]
   ): Transformer[A, V] = new Transformer[A, V] {
-    override def apply(a: A): V = transform(selector(generic.to(a)))
+    override def apply(a: A): Either[TransformError, V] = transform(selector(generic.to(a)))
   }
 
   implicit def hnilTransformer[A]: Transformer[A, HNil] = new Transformer[A, HNil] {
-    override def apply(a: A): HNil = HNil
+    override def apply(a: A): Either[TransformError, HNil] = Right(HNil)
   }
 
   implicit def identityTransformer[A]: Transformer[A, A] = new Transformer[A, A] {
-    override def apply(a: A): A = a
+    override def apply(a: A): Either[TransformError, A] = Right(a)
   }
 
-  implicit def functorTransformer[F[_], A, B](implicit
-    functor: Functor[F],
-    transform: Transformer[A, B]
-  ): Transformer[F[A], F[B]] = new Transformer[F[A], F[B]] {
-    override def apply(a: F[A]): F[B] = functor.map(a)(transform.apply)
+  implicit def functorTransformer[M[_], A, B](implicit
+    transform: Transformer[A, B],
+    traverse: Traverse[M],
+    applicative: Applicative[({type λ[X] = Either[TransformError, X]})#λ]
+  ): Transformer[M[A], M[B]] = new Transformer[M[A], M[B]] {
+    override def apply(a: M[A]): Either[TransformError, M[B]] =
+      applicative.traverse(a)(x => transform(x))
   }
 
   implicit def applicativeTransformer[F[_], A, B](implicit
     applicative: Applicative[F],
     transform: Transformer[A, B]
   ): Transformer[A, F[B]] = new Transformer[A, F[B]] {
-    override def apply(a: A): F[B] = applicative.pure(transform(a))
+    override def apply(a: A): Either[TransformError, F[B]] =
+      transform(a).map(applicative.pure)
   }
 
   implicit def emptyToStringTransformer[A](implicit
     generic: Generic.Aux[A, HNil]
   ): Transformer[A, String] = new Transformer[A, String] {
-    override def apply(a: A): String = {
+    override def apply(a: A): Either[TransformError, String] = {
       val b = a.toString
       val i = b.indexOf('(')
-      if (i >= 0) b.substring(0, i) else b
+      if (i >= 0) Right(b.substring(0, i)) else Right(b)
     }
   }
 
@@ -158,12 +178,13 @@ trait ImplicitTransformersPriority4 extends ImplicitTransformersPriority3 {
     generic: Generic.Aux[A, HNil],
     transform: Transformer[A, String]
   ): Transformer[String, A] = new Transformer[String, A] {
-    override def apply(a: String) = {
+    override def apply(a: String): Either[TransformError, A] = {
       val b = generic.from(HNil)
-      if (transform(b) != a) {
-        throw new UnsupportedOperationException(s"Can't transform $a into $b")
+      transform(b) match {
+        case Right(`a`)  => Right(b)
+        case Right(_)    => Left(TransformError(s"Can't transform '$a' into $b"))
+        case Left(error) => Left(error)
       }
-      b
     }
   }
 }
@@ -172,13 +193,14 @@ trait ImplicitTransformersPriority5 extends ImplicitTransformersPriority4 {
   implicit def optionExtractorTransformer[A, B](implicit
     transform: Transformer[A, B]
   ): Transformer[Option[A], B] = new Transformer[Option[A], B] {
-    override def apply(a: Option[A]): B = transform(a.get)
+    override def apply(a: Option[A]): Either[TransformError, B] =
+      a.map(transform.apply) getOrElse Left(TransformError("Missing required field"))
   }
 
   implicit def extractorTransformer[A, B](implicit
     generic: Generic.Aux[A, B :: HNil]
   ): Transformer[A, B] = new Transformer[A, B] {
-    override def apply(a: A): B = generic.to(a).head
+    override def apply(a: A): Either[TransformError, B] = Right(generic.to(a).head)
   }
 }
 

--- a/src/main/scala/fluent/package.scala
+++ b/src/main/scala/fluent/package.scala
@@ -2,6 +2,11 @@ import fluent.internal.Transformer
 
 package object fluent {
   implicit class TransformerOps[A](a: A) {
-    def transformTo[B](implicit transformer: Transformer[A, B]): B = transformer(a)
+    def transformTo[B](implicit transform: Transformer[A, B]): B = transform(a) match {
+      case Right(b) => b
+      case Left(TransformError.TransformErrorThrowable(error)) =>  throw error
+      case Left(error) => throw new IllegalArgumentException(s"Can't transform $a: ${error.message}")
+    }
+    def changeTo[B](implicit transformer: Transformer[A, B]): Either[TransformError, B] = transformer(a)
   }
 }


### PR DESCRIPTION
Fluent doesn't support error handling. If a transformation fails (e.g. extracting a value from `None`) an exception is thrown.

This PR makes error handling more explicit by returning an `Either[Error, Result]`.