### PR TITLE
Cross Compile Support

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -3,7 +3,7 @@ name := "fluent"
 version := "0.0.6"
 
 scalaVersion := "2.12.2"
-crossScalaVersions := Seq("2.11.7")
+crossScalaVersions := Seq("2.11.7", "2.12.2")
 
 libraryDependencies ++= Seq(
   "org.typelevel" %% "cats"      % "0.9.0",

--- a/build.sbt
+++ b/build.sbt
@@ -1,8 +1,9 @@
 name := "fluent"
 
-version := "0.0.5"
+version := "0.0.6"
 
 scalaVersion := "2.12.2"
+crossScalaVersions := Seq("2.11.7")
 
 libraryDependencies ++= Seq(
   "org.typelevel" %% "cats"      % "0.9.0",


### PR DESCRIPTION
Add 2.11 to cross compile and modified code to support 2.11.7. Good work on the project!

Cross build info is found here for ref: http://www.scala-sbt.org/1.x/docs/Cross-Build.html